### PR TITLE
Make CI pass

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,4 +37,4 @@ jobs:
         run: make gen
       - name: Fail if generation updated files
         if: github.event_name == 'pull_request'
-        run: test "$(git status -s | wc -l)" -eq 0 || (git status -s; exit 1)
+        run: test "$(git status -s | wc -l)" -eq 0 || (git status -s; echo "Generated docs are out of date. Run 'make gen' and commit again" && exit 1)

--- a/docs/tables/github_languages.md
+++ b/docs/tables/github_languages.md
@@ -11,4 +11,5 @@ The primary key for this table is **_cq_id**.
 |_cq_id (PK)|`uuid`|
 |_cq_parent_id|`uuid`|
 |full_name|`utf8`|
+|name|`utf8`|
 |languages|`list<item: utf8, nullable>`|


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

The shape of the CQ table had changed, but the docs hadn't been modified to reflect that. This causes a failure at CI time that causes all PRs to fail.

I ran `make gen` to fix the docs, and added a small explanation to the test.yaml, telling users how to fix the error. Potentially this could be avoided in the future with a pre-push hook or similar, that we install as part of a repo setup process. However, as this setup process doesn't currently exist, creating one is an increase in scope I don't have time for at the moment.

## How to test

I've verified this locally by running `test "$(git status -s | wc -l)" -eq 0 || (git status -s; echo "Generated docs are out of date. Run 'make gen' and commit again" && exit 1)` on a version of the code with out of date docs, and observed the expected behaviour

## How can we measure success?

CI passes, we can merge PRs again.
