### PR TITLE
feat: Replace PAT token authentication with Github App

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@
 # OS specific files
 .DS_Store
 Thumbs.db
+
+# test module
+test-auth

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,10 @@ lint:
 build:
 	go build -o cq-source-github-languages .
 
+.PHONY: build-test-auth
+build-test-auth:
+	go build -o test-auth ./cmd/test-auth
+
 .PHONY: gen-docs
 gen-docs: build
 	rm -rf ./docs/tables/*

--- a/client/client.go
+++ b/client/client.go
@@ -33,7 +33,6 @@ func New(ctx context.Context, logger zerolog.Logger, s *Spec) (Client, error) {
 	var appID, installationID int64
 	var privateKeyContent string
 
-	// Convert string app_id to int64
 	if s.AppID != "" {
 		var err error
 		appID, err = strconv.ParseInt(s.AppID, 10, 64)
@@ -42,7 +41,6 @@ func New(ctx context.Context, logger zerolog.Logger, s *Spec) (Client, error) {
 		}
 	}
 
-	// Convert string installation_id to int64
 	if s.InstallationID != "" {
 		var err error
 		installationID, err = strconv.ParseInt(s.InstallationID, 10, 64)
@@ -51,18 +49,16 @@ func New(ctx context.Context, logger zerolog.Logger, s *Spec) (Client, error) {
 		}
 	}
 
-	// Handle private key - prefer content over file path
-	if s.PrivateKey != "" {
-		privateKeyContent = s.PrivateKey
-	} else if s.PrivateKeyPath != "" {
+	if s.PrivateKeyPath != "" {
 		keyBytes, err := os.ReadFile(s.PrivateKeyPath)
 		if err != nil {
 			return Client{}, fmt.Errorf("failed to read private key from file %s: %w", s.PrivateKeyPath, err)
 		}
 		privateKeyContent = string(keyBytes)
+	} else if s.PrivateKey != "" {
+		privateKeyContent = s.PrivateKey
 	}
 
-	// Validate required parameters
 	if appID == 0 {
 		return Client{}, fmt.Errorf("github app id is required")
 	}

--- a/client/client.go
+++ b/client/client.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/rs/zerolog"
 )
@@ -20,7 +21,17 @@ func (c *Client) Logger() *zerolog.Logger {
 }
 
 func New(ctx context.Context, logger zerolog.Logger, s *Spec) (Client, error) {
-	// TODO: Add your client initialization here
+	// Validate GitHub App authentication parameters
+	if s.AppID == 0 {
+		return Client{}, fmt.Errorf("github app id is required")
+	}
+	if s.InstallationID == 0 {
+		return Client{}, fmt.Errorf("github app installation id is required")
+	}
+	if s.PrivateKey == "" {
+		return Client{}, fmt.Errorf("github app private key is required")
+	}
+
 	c := Client{
 		logger: logger,
 		Spec:   *s,

--- a/client/client.go
+++ b/client/client.go
@@ -37,6 +37,13 @@ func (c *Client) PrivateKey() string {
 	return c.privateKey
 }
 
+func (c *Client) Org() string {
+	if c.Spec.AppAuth != nil {
+		return c.Spec.AppAuth.Org
+	}
+	return ""
+}
+
 func New(ctx context.Context, logger zerolog.Logger, s *Spec) (Client, error) {
 	var appID, installationID int64
 	var privateKeyContent string

--- a/client/client.go
+++ b/client/client.go
@@ -3,13 +3,18 @@ package client
 import (
 	"context"
 	"fmt"
+	"os"
+	"strconv"
 
 	"github.com/rs/zerolog"
 )
 
 type Client struct {
-	logger zerolog.Logger
-	Spec   Spec
+	logger         zerolog.Logger
+	Spec           Spec
+	appID          int64
+	installationID int64
+	privateKey     string
 }
 
 func (c *Client) ID() string {
@@ -20,21 +25,73 @@ func (c *Client) Logger() *zerolog.Logger {
 	return &c.logger
 }
 
+func (c *Client) AppID() int64 {
+	return c.appID
+}
+
+func (c *Client) InstallationID() int64 {
+	return c.installationID
+}
+
+func (c *Client) PrivateKey() string {
+	return c.privateKey
+}
+
 func New(ctx context.Context, logger zerolog.Logger, s *Spec) (Client, error) {
-	// Validate GitHub App authentication parameters
-	if s.AppID == 0 {
+	var appID, installationID int64
+	var privateKeyContent string
+
+	// Validate that app_auth is provided
+	if s.AppAuth == nil {
+		return Client{}, fmt.Errorf("app_auth configuration is required")
+	}
+
+	// Convert string app_id to int64
+	if s.AppAuth.AppID != "" {
+		var err error
+		appID, err = strconv.ParseInt(s.AppAuth.AppID, 10, 64)
+		if err != nil {
+			return Client{}, fmt.Errorf("failed to parse app_id '%s' as integer: %w", s.AppAuth.AppID, err)
+		}
+	}
+
+	// Convert string installation_id to int64
+	if s.AppAuth.InstallationID != "" {
+		var err error
+		installationID, err = strconv.ParseInt(s.AppAuth.InstallationID, 10, 64)
+		if err != nil {
+			return Client{}, fmt.Errorf("failed to parse installation_id '%s' as integer: %w", s.AppAuth.InstallationID, err)
+		}
+	}
+
+	// Handle private key - prefer content over file path
+	if s.AppAuth.PrivateKey != "" {
+		privateKeyContent = s.AppAuth.PrivateKey
+	} else if s.AppAuth.PrivateKeyPath != "" {
+		keyBytes, err := os.ReadFile(s.AppAuth.PrivateKeyPath)
+		if err != nil {
+			return Client{}, fmt.Errorf("failed to read private key from file %s: %w", s.AppAuth.PrivateKeyPath, err)
+		}
+		privateKeyContent = string(keyBytes)
+	}
+
+	// Validate required parameters
+	if appID == 0 {
 		return Client{}, fmt.Errorf("github app id is required")
 	}
-	if s.InstallationID == 0 {
+	if installationID == 0 {
 		return Client{}, fmt.Errorf("github app installation id is required")
 	}
-	if s.PrivateKey == "" {
+	if privateKeyContent == "" {
 		return Client{}, fmt.Errorf("github app private key is required")
 	}
 
 	c := Client{
-		logger: logger,
-		Spec:   *s,
+		logger:         logger,
+		Spec:           *s,
+		appID:          appID,
+		installationID: installationID,
+		privateKey:     privateKeyContent,
 	}
 
 	return c, nil

--- a/client/client.go
+++ b/client/client.go
@@ -34,19 +34,36 @@ func New(ctx context.Context, logger zerolog.Logger, s *Spec) (Client, error) {
 	var appID, installationID int64
 	var privateKeyContent string
 
+	// Validate required fields
+	if s.Org == "" {
+		return Client{}, fmt.Errorf("organization is required")
+	}
+
 	if s.AppID != "" {
+		// Handle potential file interpolation syntax
+		appIDStr := strings.TrimSpace(s.AppID)
+		if strings.HasPrefix(appIDStr, "${file:") && strings.HasSuffix(appIDStr, "}") {
+			logger.Warn().Msg("app_id appears to contain file interpolation syntax - ensure CloudQuery has processed this correctly")
+		}
+
 		var err error
-		appID, err = strconv.ParseInt(s.AppID, 10, 64)
+		appID, err = strconv.ParseInt(appIDStr, 10, 64)
 		if err != nil {
-			return Client{}, fmt.Errorf("failed to parse app_id '%s' as integer: %w", s.AppID, err)
+			return Client{}, fmt.Errorf("failed to parse app_id '%s' as integer: %w", appIDStr, err)
 		}
 	}
 
 	if s.InstallationID != "" {
+		// Handle potential file interpolation syntax
+		installIDStr := strings.TrimSpace(s.InstallationID)
+		if strings.HasPrefix(installIDStr, "${file:") && strings.HasSuffix(installIDStr, "}") {
+			logger.Warn().Msg("installation_id appears to contain file interpolation syntax - ensure CloudQuery has processed this correctly")
+		}
+
 		var err error
-		installationID, err = strconv.ParseInt(s.InstallationID, 10, 64)
+		installationID, err = strconv.ParseInt(installIDStr, 10, 64)
 		if err != nil {
-			return Client{}, fmt.Errorf("failed to parse installation_id '%s' as integer: %w", s.InstallationID, err)
+			return Client{}, fmt.Errorf("failed to parse installation_id '%s' as integer: %w", installIDStr, err)
 		}
 	}
 
@@ -55,9 +72,11 @@ func New(ctx context.Context, logger zerolog.Logger, s *Spec) (Client, error) {
 		if err != nil {
 			return Client{}, fmt.Errorf("failed to read private key from file %s: %w", s.PrivateKeyPath, err)
 		}
-		privateKeyContent = string(keyBytes)
+		privateKeyContent = strings.TrimSpace(string(keyBytes))
+		logger.Info().Str("key_path", s.PrivateKeyPath).Msg("loaded private key from file")
 	} else if s.PrivateKey != "" {
-		privateKeyContent = s.PrivateKey
+		privateKeyContent = strings.TrimSpace(s.PrivateKey)
+		logger.Info().Msg("using private key from config")
 	}
 
 	if appID == 0 {
@@ -67,12 +86,18 @@ func New(ctx context.Context, logger zerolog.Logger, s *Spec) (Client, error) {
 		return Client{}, fmt.Errorf("github app installation id is required")
 	}
 	if privateKeyContent == "" {
-		return Client{}, fmt.Errorf("github app private key is required")
+		return Client{}, fmt.Errorf("github app private key is required (either private_key or private_key_path)")
 	}
 
 	if !strings.Contains(privateKeyContent, "-----BEGIN") || !strings.Contains(privateKeyContent, "-----END") {
-		return Client{}, fmt.Errorf("private key must be in PEM format")
+		return Client{}, fmt.Errorf("private key must be in PEM format with proper BEGIN/END markers")
 	}
+
+	logger.Info().
+		Int64("app_id", appID).
+		Int64("installation_id", installationID).
+		Str("org", s.Org).
+		Msg("GitHub App client configured successfully")
 
 	return Client{
 		logger:         logger,

--- a/client/client.go
+++ b/client/client.go
@@ -12,9 +12,9 @@ import (
 type Client struct {
 	logger         zerolog.Logger
 	Spec           Spec
-	appID          int64
-	installationID int64
-	privateKey     string
+	AppID          int64
+	InstallationID int64
+	PrivateKey     string
 }
 
 func (c *Client) ID() string {
@@ -25,59 +25,39 @@ func (c *Client) Logger() *zerolog.Logger {
 	return &c.logger
 }
 
-func (c *Client) AppID() int64 {
-	return c.appID
-}
-
-func (c *Client) InstallationID() int64 {
-	return c.installationID
-}
-
-func (c *Client) PrivateKey() string {
-	return c.privateKey
-}
-
 func (c *Client) Org() string {
-	if c.Spec.AppAuth != nil {
-		return c.Spec.AppAuth.Org
-	}
-	return ""
+	return c.Spec.Org
 }
 
 func New(ctx context.Context, logger zerolog.Logger, s *Spec) (Client, error) {
 	var appID, installationID int64
 	var privateKeyContent string
 
-	// Validate that app_auth is provided
-	if s.AppAuth == nil {
-		return Client{}, fmt.Errorf("app_auth configuration is required")
-	}
-
 	// Convert string app_id to int64
-	if s.AppAuth.AppID != "" {
+	if s.AppID != "" {
 		var err error
-		appID, err = strconv.ParseInt(s.AppAuth.AppID, 10, 64)
+		appID, err = strconv.ParseInt(s.AppID, 10, 64)
 		if err != nil {
-			return Client{}, fmt.Errorf("failed to parse app_id '%s' as integer: %w", s.AppAuth.AppID, err)
+			return Client{}, fmt.Errorf("failed to parse app_id '%s' as integer: %w", s.AppID, err)
 		}
 	}
 
 	// Convert string installation_id to int64
-	if s.AppAuth.InstallationID != "" {
+	if s.InstallationID != "" {
 		var err error
-		installationID, err = strconv.ParseInt(s.AppAuth.InstallationID, 10, 64)
+		installationID, err = strconv.ParseInt(s.InstallationID, 10, 64)
 		if err != nil {
-			return Client{}, fmt.Errorf("failed to parse installation_id '%s' as integer: %w", s.AppAuth.InstallationID, err)
+			return Client{}, fmt.Errorf("failed to parse installation_id '%s' as integer: %w", s.InstallationID, err)
 		}
 	}
 
 	// Handle private key - prefer content over file path
-	if s.AppAuth.PrivateKey != "" {
-		privateKeyContent = s.AppAuth.PrivateKey
-	} else if s.AppAuth.PrivateKeyPath != "" {
-		keyBytes, err := os.ReadFile(s.AppAuth.PrivateKeyPath)
+	if s.PrivateKey != "" {
+		privateKeyContent = s.PrivateKey
+	} else if s.PrivateKeyPath != "" {
+		keyBytes, err := os.ReadFile(s.PrivateKeyPath)
 		if err != nil {
-			return Client{}, fmt.Errorf("failed to read private key from file %s: %w", s.AppAuth.PrivateKeyPath, err)
+			return Client{}, fmt.Errorf("failed to read private key from file %s: %w", s.PrivateKeyPath, err)
 		}
 		privateKeyContent = string(keyBytes)
 	}
@@ -93,13 +73,11 @@ func New(ctx context.Context, logger zerolog.Logger, s *Spec) (Client, error) {
 		return Client{}, fmt.Errorf("github app private key is required")
 	}
 
-	c := Client{
+	return Client{
 		logger:         logger,
 		Spec:           *s,
-		appID:          appID,
-		installationID: installationID,
-		privateKey:     privateKeyContent,
-	}
-
-	return c, nil
+		AppID:          appID,
+		InstallationID: installationID,
+		PrivateKey:     privateKeyContent,
+	}, nil
 }

--- a/client/client.go
+++ b/client/client.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/rs/zerolog"
 )
@@ -67,6 +68,10 @@ func New(ctx context.Context, logger zerolog.Logger, s *Spec) (Client, error) {
 	}
 	if privateKeyContent == "" {
 		return Client{}, fmt.Errorf("github app private key is required")
+	}
+
+	if !strings.Contains(privateKeyContent, "-----BEGIN") || !strings.Contains(privateKeyContent, "-----END") {
+		return Client{}, fmt.Errorf("private key must be in PEM format")
 	}
 
 	return Client{

--- a/client/spec.go
+++ b/client/spec.go
@@ -1,5 +1,8 @@
 package client
 
 type Spec struct {
-	// TODO use token here
+	// GitHub App authentication parameters
+	AppID          int64  `json:"app_id,omitempty"`
+	InstallationID int64  `json:"installation_id,omitempty"`
+	PrivateKey     string `json:"private_key,omitempty"`
 }

--- a/client/spec.go
+++ b/client/spec.go
@@ -1,8 +1,14 @@
 package client
 
+type AppAuth struct {
+	Org            string `json:"org,omitempty"`
+	AppID          string `json:"app_id,omitempty"`
+	InstallationID string `json:"installation_id,omitempty"`
+	PrivateKey     string `json:"private_key,omitempty"`
+	PrivateKeyPath string `json:"private_key_path,omitempty"`
+}
+
 type Spec struct {
 	// GitHub App authentication parameters
-	AppID          int64  `json:"app_id,omitempty"`
-	InstallationID int64  `json:"installation_id,omitempty"`
-	PrivateKey     string `json:"private_key,omitempty"`
+	AppAuth *AppAuth `json:"app_auth,omitempty"`
 }

--- a/client/spec.go
+++ b/client/spec.go
@@ -1,14 +1,9 @@
 package client
 
-type AppAuth struct {
+type Spec struct {
 	Org            string `json:"org,omitempty"`
 	AppID          string `json:"app_id,omitempty"`
 	InstallationID string `json:"installation_id,omitempty"`
 	PrivateKey     string `json:"private_key,omitempty"`
 	PrivateKeyPath string `json:"private_key_path,omitempty"`
-}
-
-type Spec struct {
-	// GitHub App authentication parameters
-	AppAuth *AppAuth `json:"app_auth,omitempty"`
 }

--- a/cmd/test-auth/README.md
+++ b/cmd/test-auth/README.md
@@ -1,0 +1,277 @@
+# GitHub App Authentication Test Tool
+
+A comprehensive testing utility for validating GitHub App authentication configuration before running the CloudQuery sync process.
+
+## Overview
+
+The `test-auth` tool performs a series of authentication tests to ensure your GitHub App is properly configured and has the necessary permissions to access your organisation's repositories. This helps identify and resolve authentication issues early, preventing failures during the actual CloudQuery sync.
+
+## Features
+
+- **Multiple Authentication Tests**: Validates both JWT and installation token authentication
+- **Rate Limit Monitoring**: Shows remaining API calls and reset times
+- **Permission Verification**: Checks GitHub App installation permissions
+- **Repository Access Testing**: Lists accessible repositories and tests language detection
+- **Performance Testing**: Benchmarks language fetching across multiple repositories
+- **Comprehensive Error Reporting**: Provides detailed error messages with troubleshooting guidance
+- **Flexible Configuration**: Supports both environment variables and command-line flags
+
+## Building the Tool
+
+```bash
+make build-test-auth
+```
+
+This creates a `test-auth` binary in the project root.
+
+## Configuration
+
+The tool supports multiple ways to provide authentication credentials, with command-line flags taking precedence over environment variables.
+
+### Environment Variables
+
+```bash
+export GITHUB_APP_ID="your_app_id"
+export GITHUB_INSTALLATION_ID="your_installation_id"
+export GITHUB_PRIVATE_KEY_PATH="/path/to/private-key.pem"
+# OR
+export GITHUB_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----..."
+```
+
+### Command-Line Flags
+
+```bash
+./test-auth \
+  -app-id "123456" \
+  -install-id "12345678" \
+  -key-path "/path/to/private-key.pem" \
+  -owner "your-org" \
+  -repo "test-repo"
+```
+
+## Usage Examples
+
+### Basic Authentication Test
+
+```bash
+# Using environment variables
+./test-auth
+
+# Using command-line flags
+./test-auth -app-id "123456" -install-id "12345678" -key-path "/path/to/key.pem"
+```
+
+### Test Specific organisation/Repository
+
+```bash
+./test-auth -owner "guardian" -repo "frontend"
+```
+
+### Using Direct Private Key
+
+```bash
+./test-auth \
+  -app-id "123456" \
+  -install-id "12345678" \
+  -key "-----BEGIN RSA PRIVATE KEY-----
+MIIEpAIBAAKCAQEA...
+-----END RSA PRIVATE KEY-----"
+```
+
+## Command-Line Options
+
+| Flag | Environment Variable | Description |
+|------|---------------------|-------------|
+| `-app-id` | `GITHUB_APP_ID` | GitHub App ID |
+| `-install-id` | `GITHUB_INSTALLATION_ID` | GitHub App Installation ID |
+| `-key-path` | `GITHUB_PRIVATE_KEY_PATH` | Path to private key file |
+| `-key` | `GITHUB_PRIVATE_KEY` | Private key content directly |
+| `-owner` | N/A | Repository owner/organisation (default: "guardian") |
+| `-repo` | N/A | Repository name for testing (default: "cq-source-github-languages") |
+
+## Test Sequence
+
+The tool performs the following tests in order:
+
+### 1. 🔍 Client Configuration
+- Validates input parameters
+- Creates and configures the authentication client
+- Parses and validates private key format
+
+### 2. 🔍 API Access and Rate Limits
+- Tests basic API connectivity
+- Shows current rate limit status
+- Displays reset times for different API endpoints
+
+### 3. 🔍 Installation Permissions
+- Retrieves GitHub App installation details
+- Shows installation permissions (metadata, contents, etc.)
+- Validates app has access to the specified installation
+
+### 4. 🔍 Repository Access
+- Lists repositories accessible to the GitHub App
+- Shows first few repositories with their visibility status
+- Counts total accessible repositories
+
+### 5. 🔍 organisation Access
+- Tests organisation-level API access
+- Retrieves organisation details and repository counts
+- Validates organisation permissions
+
+### 6. 🔍 Language Detection
+- Tests repository language detection on a specific repository
+- Validates the core functionality used by the CloudQuery plugin
+- Shows detected languages for the test repository
+
+### 7. 🔍 Performance Testing
+- Fetches languages for multiple organization repositories
+- Measures processing time and success rate
+- Provides performance metrics
+
+## Output Example
+
+```
+Configuration:
+App ID: 123456 (from environment variable)
+Installation ID: 12345678 (from CLI flag)
+Key Path: /path/to/key.pem (from environment variable)
+
+✅ Client created successfully!
+App ID: 123456
+Installation ID: 12345678
+Organization: guardian
+
+✅ GitHub client created successfully!
+
+🔍 Testing API access and rate limits...
+✅ Rate limits retrieved:
+  Core: 4850/5000 (resets at 2024-01-15 14:30:00)
+  Search: 30/30 (resets at 2024-01-15 13:35:00)
+
+🔍 Testing installation permissions...
+✅ Installation details:
+  Account: guardian
+  Target Type: Organization
+  Created: 2024-01-10 10:15:30
+  Updated: 2024-01-15 12:20:45
+  Permissions:
+    Metadata: read
+    Contents: read
+
+🎉 All authentication tests completed successfully!
+Your GitHub App authentication is properly configured.
+```
+
+## Private Key Formats
+
+The tool supports multiple private key formats:
+
+### RSA PKCS#1 Format
+```
+-----BEGIN RSA PRIVATE KEY-----
+MIIEpAIBAAKCAQEA...
+-----END RSA PRIVATE KEY-----
+```
+
+### PKCS#8 Format
+```
+-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC...
+-----END PRIVATE KEY-----
+```
+
+### Base64 Encoded Keys
+The tool automatically detects and decodes base64-encoded private keys.
+
+## Troubleshooting
+
+### Common Issues
+
+#### JWT Token Decode Error
+```
+❌ Error getting installation details: GET https://api.github.com/app/installations/12345: 401 A JSON web token could not be decoded
+```
+
+**Solutions:**
+- Verify App ID is correct
+- Check private key format (must be PEM-encoded RSA key)
+- Ensure private key matches the GitHub App
+- Verify system clock is synchronized (JWT tokens are time-sensitive)
+
+#### Installation Not Found
+```
+❌ Error creating GitHub client: failed to create installation token (HTTP 404)
+```
+
+**Solutions:**
+- Verify Installation ID is correct
+- Check that the GitHub App is installed on the target organization
+- Ensure the App ID matches the installed GitHub App
+
+#### Permission Denied
+```
+❌ Error listing accessible repositories: GET https://api.github.com/installation/repositories: 403 Forbidden
+```
+
+**Solutions:**
+- Verify GitHub App has necessary permissions (Contents: Read, Metadata: Read)
+- Check that the app is installed with repository access
+- Ensure the organization allows the GitHub App
+
+#### Private Key Format Issues
+```
+❌ Error processing private key: unsupported private key format
+```
+
+**Solutions:**
+- Ensure key is in PEM format with proper headers/footers
+- Convert key to RSA PKCS#1 or PKCS#8 format if necessary
+- Check for extra whitespace or encoding issues
+
+### Debug Information
+
+The tool provides extensive debug output including:
+- Private key format detection
+- JWT token claims and timing
+- API response details
+- Rate limit information
+- Installation permissions
+
+## Integration with CloudQuery
+
+Once `test-auth` completes successfully, you can use the same credentials with CloudQuery:
+
+```yaml
+kind: source
+spec:
+  name: "github-languages"
+  path: "guardian/github-languages"
+  version: "v1.0.0"
+  destinations:
+    - "postgresql"
+  spec:
+    org: "guardian"
+    app_id: "${GITHUB_APP_ID}"
+    installation_id: "${GITHUB_INSTALLATION_ID}"
+    private_key_path: "${GITHUB_PRIVATE_KEY_PATH}"
+```
+
+## Exit Codes
+
+- `0`: All tests passed successfully
+- `1`: Configuration error or test failure
+
+## Requirements
+
+- Go 1.24.3 or later
+- Valid GitHub App with appropriate permissions
+- Network access to GitHub API (api.github.com)
+
+## Support
+
+If you encounter issues not covered in this README:
+
+1. Run `test-auth` with verbose output to get detailed error messages
+2. Check GitHub App configuration and permissions
+3. Verify network connectivity to GitHub API
+4. Ensure system time is synchronized for JWT token validation

--- a/cmd/test-auth/main.go
+++ b/cmd/test-auth/main.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"encoding/base64"
+	"flag"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/guardian/cq-source-github-languages/internal/github"
+)
+
+// sanitizePrivateKey ensures the private key is properly formatted with newlines
+// and handles base64 encoded keys
+func sanitizePrivateKey(key string) ([]byte, error) {
+	// Trim any extra whitespace
+	key = strings.TrimSpace(key)
+
+	// Check if the key is base64 encoded (doesn't start with PEM headers)
+	if !strings.HasPrefix(key, "-----BEGIN") {
+		// Try to decode as base64
+		fmt.Println("Key doesn't start with PEM header, attempting base64 decode...")
+		decoded, err := base64.StdEncoding.DecodeString(key)
+		if err != nil {
+			return nil, fmt.Errorf("key doesn't appear to be in PEM format and failed base64 decoding: %w", err)
+		}
+
+		// Check if decoded content looks like a PEM key
+		decodedStr := string(decoded)
+		if strings.Contains(decodedStr, "-----BEGIN") {
+			fmt.Println("Successfully decoded base64 key to PEM format")
+			key = decodedStr
+		} else {
+			return nil, fmt.Errorf("base64 decoded content doesn't appear to be a valid PEM key")
+		}
+	}
+
+	// Replace literal "\n" with actual newlines if they exist
+	key = strings.ReplaceAll(key, "\\n", "\n")
+
+	// Ensure key has proper BEGIN and END markers with newlines
+	if !strings.Contains(key, "-----BEGIN") {
+		fmt.Println("Warning: Private key does not contain BEGIN marker")
+	}
+	if !strings.Contains(key, "-----END") {
+		fmt.Println("Warning: Private key does not contain END marker")
+	}
+
+	return []byte(key), nil
+}
+
+func main() {
+	// Define flags for command line arguments
+	appIDStr := flag.String("app-id", os.Getenv("GITHUB_APP_ID"), "GitHub App ID (or set GITHUB_APP_ID env)")
+	installIDStr := flag.String("install-id", os.Getenv("GITHUB_INSTALLATION_ID"), "GitHub Installation ID (or set GITHUB_INSTALLATION_ID env)")
+	keyPath := flag.String("key-path", os.Getenv("GITHUB_PRIVATE_KEY_PATH"), "Path to GitHub App private key file (or set GITHUB_PRIVATE_KEY_PATH env)")
+	key := flag.String("key", os.Getenv("GITHUB_PRIVATE_KEY"), "GitHub App private key contents directly (or set GITHUB_PRIVATE_KEY env)")
+	owner := flag.String("owner", "guardian", "GitHub repository owner/organization")
+	repo := flag.String("repo", "cq-source-github-languages", "GitHub repository name")
+
+	flag.Parse()
+
+	// Validate inputs
+	if *appIDStr == "" || *installIDStr == "" || (*keyPath == "" && *key == "") {
+		fmt.Println("Error: Required parameters missing. Please provide app-id, install-id, and either key or key-path.")
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	// Convert string IDs to int64
+	appID, err := strconv.ParseInt(*appIDStr, 10, 64)
+	if err != nil {
+		fmt.Printf("Error parsing app ID: %v\n", err)
+		os.Exit(1)
+	}
+
+	installID, err := strconv.ParseInt(*installIDStr, 10, 64)
+	if err != nil {
+		fmt.Printf("Error parsing installation ID: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Determine which key to use - prefer direct key if provided
+	var privateKey []byte
+	if *key != "" {
+		privateKey, err = sanitizePrivateKey(*key)
+		if err != nil {
+			fmt.Printf("Error processing private key: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Println("Using private key provided directly via --key flag or GITHUB_PRIVATE_KEY env var")
+	} else {
+		// Read private key file
+		keyData, err := os.ReadFile(*keyPath)
+		if err != nil {
+			fmt.Printf("Error reading private key file: %v\n", err)
+			os.Exit(1)
+		}
+		privateKey, err = sanitizePrivateKey(string(keyData))
+		if err != nil {
+			fmt.Printf("Error processing private key from file: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Printf("Using private key from file: %s\n", *keyPath)
+	}
+
+	fmt.Println("Authenticating with GitHub App...")
+	fmt.Printf("App ID: %d\n", appID)
+	fmt.Printf("Installation ID: %d\n", installID)
+
+	// Create GitHub client
+	client, err := github.NewGitHubAppClient(appID, installID, privateKey)
+	if err != nil {
+		fmt.Printf("Error creating GitHub client: %v\n", err)
+		fmt.Println("\nTROUBLESHOOTING TIPS:")
+		fmt.Println("1. Ensure your private key is a valid PEM-encoded RSA private key")
+		fmt.Println("2. The key should start with '-----BEGIN RSA PRIVATE KEY-----' and end with '-----END RSA PRIVATE KEY-----'")
+		fmt.Println("3. If your key is base64 encoded, the tool will attempt to decode it")
+		fmt.Println("4. Check that your App ID and Installation ID are correct")
+		os.Exit(1)
+	}
+
+	fmt.Printf("Fetching languages for %s/%s...\n", *owner, *repo)
+
+	// Test by fetching languages for a repository
+	langs, err := client.GetLanguages(*owner, *repo)
+	if err != nil {
+		fmt.Printf("Error fetching languages: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Print results
+	fmt.Println("Authentication successful!")
+	fmt.Printf("Repository: %s\n", langs.FullName)
+	fmt.Println("Languages:")
+	for _, lang := range langs.Languages {
+		fmt.Printf("- %s\n", lang)
+	}
+}

--- a/cmd/test-auth/main.go
+++ b/cmd/test-auth/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/base64"
 	"flag"
 	"fmt"
@@ -109,8 +110,11 @@ func main() {
 	fmt.Printf("App ID: %d\n", appID)
 	fmt.Printf("Installation ID: %d\n", installID)
 
+	// Create a context for the API calls
+	ctx := context.Background()
+
 	// Create GitHub client
-	client, err := github.NewGitHubAppClient(appID, installID, privateKey)
+	client, err := github.NewGitHubAppClient(ctx, appID, installID, privateKey)
 	if err != nil {
 		fmt.Printf("Error creating GitHub client: %v\n", err)
 		fmt.Println("\nTROUBLESHOOTING TIPS:")
@@ -124,7 +128,7 @@ func main() {
 	fmt.Printf("Fetching languages for %s/%s...\n", *owner, *repo)
 
 	// Test by fetching languages for a repository
-	langs, err := client.GetLanguages(*owner, *repo)
+	langs, err := client.GetLanguages(ctx, *owner, *repo)
 	if err != nil {
 		fmt.Printf("Error fetching languages: %v\n", err)
 		os.Exit(1)

--- a/cmd/test-auth/main.go
+++ b/cmd/test-auth/main.go
@@ -5,12 +5,17 @@ import (
 	"encoding/base64"
 	"flag"
 	"fmt"
+	"net/http"
 	"os"
 	"strings"
+	"time"
 
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/google/go-github/v57/github"
 	"github.com/guardian/cq-source-github-languages/client"
-	"github.com/guardian/cq-source-github-languages/internal/github"
+	githubinternal "github.com/guardian/cq-source-github-languages/internal/github"
 	"github.com/rs/zerolog"
+	"golang.org/x/oauth2"
 )
 
 // sanitizePrivateKey ensures the private key is properly formatted with newlines
@@ -41,15 +46,79 @@ func sanitizePrivateKey(key string) ([]byte, error) {
 	// Replace literal "\n" with actual newlines if they exist
 	key = strings.ReplaceAll(key, "\\n", "\n")
 
-	// Ensure key has proper BEGIN and END markers with newlines
+	// Validate the key format more thoroughly
 	if !strings.Contains(key, "-----BEGIN") {
-		fmt.Println("Warning: Private key does not contain BEGIN marker")
+		return nil, fmt.Errorf("private key does not contain BEGIN marker")
 	}
 	if !strings.Contains(key, "-----END") {
-		fmt.Println("Warning: Private key does not contain END marker")
+		return nil, fmt.Errorf("private key does not contain END marker")
 	}
 
+	// Check for supported key types
+	supportedTypes := []string{
+		"-----BEGIN RSA PRIVATE KEY-----",
+		"-----BEGIN PRIVATE KEY-----", // PKCS#8 format
+	}
+
+	isSupported := false
+	keyType := "unknown"
+	for _, keyTypeMarker := range supportedTypes {
+		if strings.Contains(key, keyTypeMarker) {
+			isSupported = true
+			if strings.Contains(keyTypeMarker, "RSA") {
+				keyType = "RSA (PKCS#1)"
+			} else {
+				keyType = "PKCS#8"
+			}
+			break
+		}
+	}
+
+	if !isSupported {
+		return nil, fmt.Errorf("unsupported private key format - must be RSA PKCS#1 or PKCS#8 format")
+	}
+
+	fmt.Printf("Detected private key format: %s\n", keyType)
+	fmt.Printf("Private key length: %d characters\n", len(key))
+
 	return []byte(key), nil
+}
+
+// createJWTAuthenticatedClient creates a GitHub client authenticated with JWT (for app-level operations)
+func createJWTAuthenticatedClient(appID int64, privateKeyPEM []byte) (*github.Client, error) {
+	// Parse the private key
+	privateKey, err := jwt.ParseRSAPrivateKeyFromPEM(privateKeyPEM)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse private key: %w", err)
+	}
+
+	// Create JWT token with proper claims
+	now := time.Now()
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims{
+		"iat": jwt.NewNumericDate(now.Add(-60 * time.Second)), // 1 minute ago to account for clock skew
+		"exp": jwt.NewNumericDate(now.Add(10 * time.Minute)),  // 10 minutes from now (max allowed)
+		"iss": appID,
+	})
+
+	// Sign the token
+	signedToken, err := token.SignedString(privateKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to sign JWT token: %w", err)
+	}
+
+	// Create client with JWT authentication
+	client := github.NewClient(&http.Client{
+		Transport: &oauth2.Transport{
+			Source: oauth2.StaticTokenSource(
+				&oauth2.Token{
+					AccessToken: signedToken,
+					TokenType:   "Bearer",
+				},
+			),
+		},
+	})
+
+	return client, nil
 }
 
 func main() {
@@ -124,37 +193,156 @@ func main() {
 		fmt.Println("2. The key should start with '-----BEGIN RSA PRIVATE KEY-----' and end with '-----END RSA PRIVATE KEY-----'")
 		fmt.Println("3. If your key is base64 encoded, the tool will attempt to decode it")
 		fmt.Println("4. Check that your App ID and Installation ID are correct")
+		fmt.Println("5. Verify the GitHub App has the necessary permissions for the organization")
 		os.Exit(1)
 	}
 
-	fmt.Printf("Client created successfully!\n")
+	fmt.Printf("✅ Client created successfully!\n")
 	fmt.Printf("App ID: %d\n", c.AppID)
 	fmt.Printf("Installation ID: %d\n", c.InstallationID)
+	fmt.Printf("Organization: %s\n", c.Org())
 
 	// Create GitHub client directly for testing
 	privateKeyBytes := []byte(c.PrivateKey)
-	gitHubClient, err := github.NewGitHubAppClient(ctx, c.AppID, c.InstallationID, privateKeyBytes)
+	gitHubClient, err := githubinternal.NewGitHubAppClient(ctx, c.AppID, c.InstallationID, privateKeyBytes)
 	if err != nil {
-		fmt.Printf("Error creating GitHub client: %v\n", err)
+		fmt.Printf("❌ Error creating GitHub client: %v\n", err)
 		os.Exit(1)
 	}
 
-	fmt.Printf("Fetching languages for %s/%s...\n", *owner, *repo)
+	fmt.Printf("✅ GitHub client created successfully!\n\n")
 
-	// Test by fetching languages for a repository
+	// Test 1: Check rate limits
+	fmt.Println("🔍 Testing API access and rate limits...")
+	rateLimits, _, err := gitHubClient.GitHubClient.RateLimit.Get(ctx)
+	if err != nil {
+		fmt.Printf("❌ Error checking rate limits: %v\n", err)
+	} else {
+		fmt.Printf("✅ Rate limits retrieved:\n")
+		fmt.Printf("  Core: %d/%d (resets at %v)\n",
+			rateLimits.Core.Remaining, rateLimits.Core.Limit, rateLimits.Core.Reset.Time)
+		fmt.Printf("  Search: %d/%d (resets at %v)\n",
+			rateLimits.Search.Remaining, rateLimits.Search.Limit, rateLimits.Search.Reset.Time)
+	}
+
+	// Test 2: Check installation permissions (requires JWT authentication, not installation token)
+	fmt.Println("\n🔍 Testing installation permissions...")
+
+	// Create a separate JWT-authenticated client for app-level operations
+	jwtClient, err := createJWTAuthenticatedClient(c.AppID, privateKeyBytes)
+	if err != nil {
+		fmt.Printf("❌ Error creating JWT client: %v\n", err)
+	} else {
+		installation, _, err := jwtClient.Apps.GetInstallation(ctx, c.InstallationID)
+		if err != nil {
+			fmt.Printf("❌ Error getting installation details: %v\n", err)
+			fmt.Println("  This might indicate:")
+			fmt.Println("  - Incorrect App ID or Installation ID")
+			fmt.Println("  - GitHub App doesn't have access to this installation")
+			fmt.Println("  - JWT token generation issue")
+		} else {
+			fmt.Printf("✅ Installation details:\n")
+			fmt.Printf("  Account: %s\n", *installation.Account.Login)
+			fmt.Printf("  Target Type: %s\n", *installation.TargetType)
+			fmt.Printf("  Created: %v\n", installation.CreatedAt.Time)
+			fmt.Printf("  Updated: %v\n", installation.UpdatedAt.Time)
+
+			if installation.Permissions != nil {
+				fmt.Printf("  Permissions:\n")
+				if installation.Permissions.Metadata != nil {
+					fmt.Printf("    Metadata: %s\n", *installation.Permissions.Metadata)
+				}
+				if installation.Permissions.Contents != nil {
+					fmt.Printf("    Contents: %s\n", *installation.Permissions.Contents)
+				}
+			}
+		}
+	}
+
+	// Test 3: List accessible repositories
+	fmt.Println("\n🔍 Testing repository access...")
+	repos, _, err := gitHubClient.GitHubClient.Apps.ListRepos(ctx, nil)
+	if err != nil {
+		fmt.Printf("❌ Error listing accessible repositories: %v\n", err)
+	} else {
+		fmt.Printf("✅ App can access %d repositories\n", len(repos.Repositories))
+		if len(repos.Repositories) > 0 {
+			fmt.Printf("  First few repositories:\n")
+			for i, repo := range repos.Repositories {
+				if i >= 3 { // Only show first 3
+					fmt.Printf("  ... and %d more\n", len(repos.Repositories)-3)
+					break
+				}
+				fmt.Printf("    - %s (private: %v)\n", *repo.FullName, *repo.Private)
+			}
+		}
+	}
+
+	// Test 4: Test organization access
+	fmt.Printf("\n🔍 Testing organization access for '%s'...\n", *owner)
+	org, _, err := gitHubClient.GitHubClient.Organizations.Get(ctx, *owner)
+	if err != nil {
+		fmt.Printf("❌ Error accessing organization: %v\n", err)
+	} else {
+		fmt.Printf("✅ Organization access successful:\n")
+		fmt.Printf("  Name: %s\n", *org.Name)
+		fmt.Printf("  Public Repos: %d\n", *org.PublicRepos)
+		fmt.Printf("  Private Repos: %d\n", *org.TotalPrivateRepos)
+	}
+
+	// Test 5: Test repository languages (original test)
+	fmt.Printf("\n🔍 Testing repository languages for %s/%s...\n", *owner, *repo)
 	langs, err := gitHubClient.GetLanguages(ctx, *owner, *repo)
 	if err != nil {
-		fmt.Printf("Error fetching languages: %v\n", err)
+		fmt.Printf("❌ Error fetching languages: %v\n", err)
+		fmt.Println("\nPossible issues:")
+		fmt.Println("- Repository doesn't exist or isn't accessible")
+		fmt.Println("- GitHub App doesn't have 'Contents' permission")
+		fmt.Println("- Repository is private and app lacks access")
 		os.Exit(1)
 	}
 
-	// Print results
-	fmt.Println("Authentication successful!")
+	fmt.Printf("✅ Language detection successful!\n")
 	fmt.Printf("Repository: %s\n", langs.FullName)
-	fmt.Println("Languages:")
+	fmt.Printf("Languages (%d total):\n", len(langs.Languages))
 	for _, lang := range langs.Languages {
-		fmt.Printf("- %s\n", lang)
+		fmt.Printf("  - %s\n", lang)
 	}
+
+	// Test 6: Performance test - fetch languages for multiple repos
+	fmt.Println("\n🔍 Performance test - fetching languages for organization repos...")
+	startTime := time.Now()
+
+	orgRepos, _, err := gitHubClient.GitHubClient.Repositories.ListByOrg(ctx, *owner, nil)
+	if err != nil {
+		fmt.Printf("❌ Error listing org repositories: %v\n", err)
+	} else {
+		fmt.Printf("✅ Found %d repositories in organization\n", len(orgRepos))
+
+		// Test first 3 repos for performance
+		testCount := 3
+		if len(orgRepos) < testCount {
+			testCount = len(orgRepos)
+		}
+
+		successCount := 0
+		for i := 0; i < testCount; i++ {
+			repo := orgRepos[i]
+			if repo.Owner != nil && repo.Owner.Login != nil && repo.Name != nil {
+				_, err := gitHubClient.GetLanguages(ctx, *repo.Owner.Login, *repo.Name)
+				if err == nil {
+					successCount++
+				}
+			}
+		}
+
+		elapsed := time.Since(startTime)
+		fmt.Printf("✅ Performance test completed: %d/%d repos processed in %v\n",
+			successCount, testCount, elapsed)
+	}
+
+	fmt.Println("\n🎉 All authentication tests completed successfully!")
+	fmt.Println("Your GitHub App authentication is properly configured.")
 }
 
 // getValueSource determines if a value came from CLI flag or environment variable

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/aws/smithy-go v1.22.3 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.2 // indirect
 	github.com/cloudquery/codegen v0.3.28 // indirect
+	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.7 // indirect
@@ -39,6 +40,7 @@ require (
 	go.opentelemetry.io/otel/log v0.12.2 // indirect
 	go.opentelemetry.io/otel/sdk/log v0.12.2 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.36.0 // indirect
+	golang.org/x/oauth2 v0.30.0 // indirect
 )
 
 replace github.com/apache/arrow/go/v14 => github.com/cloudquery/arrow/go/v14 v14.0.0-20230904001200-cd3d4114faa0

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,9 @@ go 1.24.3
 
 require (
 	github.com/cloudquery/plugin-sdk/v4 v4.84.1
+	github.com/golang-jwt/jwt/v4 v4.5.2
 	github.com/rs/zerolog v1.34.0
+	golang.org/x/oauth2 v0.30.0
 )
 
 require (
@@ -27,7 +29,6 @@ require (
 	github.com/aws/smithy-go v1.22.3 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.2 // indirect
 	github.com/cloudquery/codegen v0.3.28 // indirect
-	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.7 // indirect
@@ -40,7 +41,6 @@ require (
 	go.opentelemetry.io/otel/log v0.12.2 // indirect
 	go.opentelemetry.io/otel/sdk/log v0.12.2 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.36.0 // indirect
-	golang.org/x/oauth2 v0.30.0 // indirect
 )
 
 replace github.com/apache/arrow/go/v14 => github.com/cloudquery/arrow/go/v14 v14.0.0-20230904001200-cd3d4114faa0

--- a/go.sum
+++ b/go.sum
@@ -79,6 +79,8 @@ github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre
 github.com/goccy/go-json v0.10.5 h1:Fq85nIqj+gXn/S5ahsiTlK3TmC85qgirsdTP/+DeaC4=
 github.com/goccy/go-json v0.10.5/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
+github.com/golang-jwt/jwt/v4 v4.5.2 h1:YtQM7lnr8iZ+j5q71MGKkNw9Mn7AjHM68uc9g5fXeUI=
+github.com/golang-jwt/jwt/v4 v4.5.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
 github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
@@ -207,6 +209,8 @@ golang.org/x/mod v0.24.0 h1:ZfthKaKaT4NrhGVZHO1/WDTwGES4De8KtWO0SIbNJMU=
 golang.org/x/mod v0.24.0/go.mod h1:IXM97Txy2VM4PJ3gI61r1YEk/gAj6zAHN3AdZt6S9Ww=
 golang.org/x/net v0.40.0 h1:79Xs7wF06Gbdcg4kdCCIQArK11Z1hr5POQ6+fIYHNuY=
 golang.org/x/net v0.40.0/go.mod h1:y0hY0exeL2Pku80/zKK7tpntoX23cqL3Oa6njdgRtds=
+golang.org/x/oauth2 v0.30.0 h1:dnDm7JmhM45NNpd8FDDeLhK6FwqbOf4MLCM9zb1BOHI=
+golang.org/x/oauth2 v0.30.0/go.mod h1:B++QgG3ZKulg6sRPGD/mqlHQs5rB3Ml9erfeDY7xKlU=
 golang.org/x/sync v0.14.0 h1:woo0S4Yywslg6hp4eUFjTVOyKt0RookbpAHG4c1HmhQ=
 golang.org/x/sync v0.14.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -2,13 +2,17 @@ package github
 
 import (
 	"context"
+	"fmt"
+	"net/http"
+	"time"
 
+	"github.com/golang-jwt/jwt/v4"
 	"github.com/google/go-github/v57/github"
 	"golang.org/x/exp/maps"
+	"golang.org/x/oauth2"
 )
 
 type Languages struct {
-	// TODO find a way to share this with table.go
 	FullName  string
 	Name      string
 	Languages []string
@@ -18,10 +22,69 @@ type Client struct {
 	GitHubClient *github.Client
 }
 
-func CustomClient(token string) *Client {
-	return &Client{
-		GitHubClient: github.NewClient(nil).WithAuthToken(token),
+// NewGitHubAppClient creates a new GitHub client authenticated as a GitHub App installation
+func NewGitHubAppClient(appID, installationID int64, privateKeyPEM []byte) (*Client, error) {
+	// Create a new transport using the GitHub App authentication
+	itr, err := newGitHubAppTransport(appID, installationID, privateKeyPEM)
+	if err != nil {
+		return nil, err
 	}
+
+	// Create a new client with the transport
+	httpClient := &http.Client{Transport: itr}
+	client := github.NewClient(httpClient)
+
+	return &Client{
+		GitHubClient: client,
+	}, nil
+}
+
+// newGitHubAppTransport creates a new http.RoundTripper that authenticates as a GitHub App installation
+func newGitHubAppTransport(appID, installationID int64, privateKeyPEM []byte) (http.RoundTripper, error) {
+	// Parse the private key
+	privateKey, err := jwt.ParseRSAPrivateKeyFromPEM(privateKeyPEM)
+	if err != nil {
+		// Provide more specific error for key parsing issues
+		return nil, fmt.Errorf("failed to parse private key: %w - ensure key is a valid PEM-encoded RSA private key", err)
+	}
+
+	// Create JWT token for GitHub App
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims{
+		"iat": jwt.NewNumericDate(jwt.TimeFunc().Add(-30 * time.Second)),
+		"exp": jwt.NewNumericDate(jwt.TimeFunc().Add(5 * time.Minute)),
+		"iss": appID,
+	})
+
+	signedToken, err := token.SignedString(privateKey)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create an authenticated client for getting an installation token
+	client := github.NewClient(&http.Client{
+		Transport: &oauth2.Transport{
+			Source: oauth2.StaticTokenSource(
+				&oauth2.Token{AccessToken: signedToken},
+			),
+		},
+	})
+
+	// Get installation token
+	installToken, _, err := client.Apps.CreateInstallationToken(
+		context.Background(),
+		installationID,
+		&github.InstallationTokenOptions{},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// Return transport that uses the installation token
+	return &oauth2.Transport{
+		Source: oauth2.StaticTokenSource(
+			&oauth2.Token{AccessToken: *installToken.Token},
+		),
+	}, nil
 }
 
 func (c *Client) GetLanguages(owner string, name string) (*Languages, error) {

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"encoding/pem"
 	"fmt"
 	"net/http"
 	"time"
@@ -41,48 +42,96 @@ func NewGitHubAppClient(ctx context.Context, appID, installationID int64, privat
 
 // newGitHubAppTransport creates a new http.RoundTripper that authenticates as a GitHub App installation
 func newGitHubAppTransport(ctx context.Context, appID, installationID int64, privateKeyPEM []byte) (http.RoundTripper, error) {
-	// Parse the private key
 	privateKey, err := jwt.ParseRSAPrivateKeyFromPEM(privateKeyPEM)
 	if err != nil {
-		// Provide more specific error for key parsing issues
-		return nil, fmt.Errorf("failed to parse private key: %w - ensure key is a valid PEM-encoded RSA private key", err)
+		// Debug: Check if the key looks like a valid PEM key
+		keyStr := string(privateKeyPEM)
+		if len(keyStr) < 100 {
+			return nil, fmt.Errorf("private key appears too short (%d chars) - ensure full key is provided", len(keyStr))
+		}
+		// Use encoding/pem to decode the PEM block
+		block, _ := pem.Decode([]byte(keyStr))
+		if block == nil {
+			return nil, fmt.Errorf("private key is not a valid PEM format: %w", err)
+		}
+		return nil, fmt.Errorf("failed to parse RSA private key from PEM: %w - ensure key is RSA format and not EC/Ed25519", err)
 	}
 
-	// Create JWT token for GitHub App
-	token := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims{
-		"iat": jwt.NewNumericDate(jwt.TimeFunc().Add(-30 * time.Second)),
-		"exp": jwt.NewNumericDate(jwt.TimeFunc().Add(5 * time.Minute)),
+	// Create JWT token with proper timing and claims
+	now := time.Now()
+	claims := jwt.MapClaims{
+		"iat": jwt.NewNumericDate(now.Add(-60 * time.Second)), // 1 minute ago to account for clock skew
+		"exp": jwt.NewNumericDate(now.Add(10 * time.Minute)),  // 10 minutes from now (max allowed)
 		"iss": appID,
-	})
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
 
 	signedToken, err := token.SignedString(privateKey)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to sign JWT token: %w", err)
 	}
+
+	// Debug: Print token claims for debugging
+	fmt.Printf("JWT Claims: iss=%d, iat=%v, exp=%v\n",
+		appID,
+		claims["iat"].(*jwt.NumericDate).Time,
+		claims["exp"].(*jwt.NumericDate).Time)
 
 	// Create an authenticated client for getting an installation token
 	client := github.NewClient(&http.Client{
 		Transport: &oauth2.Transport{
 			Source: oauth2.StaticTokenSource(
-				&oauth2.Token{AccessToken: signedToken},
+				&oauth2.Token{
+					AccessToken: signedToken,
+					TokenType:   "Bearer",
+				},
 			),
 		},
 	})
 
-	// Get installation token
-	installToken, _, err := client.Apps.CreateInstallationToken(
-		ctx,
+	// Test the JWT token first by trying to list app installations
+	fmt.Printf("Testing JWT token by listing app installations...\n")
+	installations, _, err := client.Apps.ListInstallations(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("JWT token validation failed when listing installations: %w - check App ID (%d) and private key", err, appID)
+	}
+	fmt.Printf("JWT token valid - found %d installations\n", len(installations))
+
+	// Get installation token with timeout context
+	timeoutCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	fmt.Printf("Attempting to create installation token for installation ID: %d\n", installationID)
+
+	installToken, resp, err := client.Apps.CreateInstallationToken(
+		timeoutCtx,
 		installationID,
 		&github.InstallationTokenOptions{},
 	)
 	if err != nil {
-		return nil, err
+		// Provide more detailed error information
+		if resp != nil {
+			return nil, fmt.Errorf("failed to create installation token (HTTP %d): %w - verify App ID (%d) and Installation ID (%d) are correct",
+				resp.StatusCode, err, appID, installationID)
+		}
+		return nil, fmt.Errorf("failed to create installation token: %w - verify App ID (%d) and Installation ID (%d) are correct",
+			err, appID, installationID)
 	}
+
+	if installToken == nil || installToken.Token == nil {
+		return nil, fmt.Errorf("received nil installation token")
+	}
+
+	fmt.Printf("Successfully created installation token (expires: %v)\n", installToken.ExpiresAt)
 
 	// Return transport that uses the installation token
 	return &oauth2.Transport{
 		Source: oauth2.StaticTokenSource(
-			&oauth2.Token{AccessToken: *installToken.Token},
+			&oauth2.Token{
+				AccessToken: *installToken.Token,
+				TokenType:   "token",
+			},
 		),
 	}, nil
 }

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -23,9 +23,9 @@ type Client struct {
 }
 
 // NewGitHubAppClient creates a new GitHub client authenticated as a GitHub App installation
-func NewGitHubAppClient(appID, installationID int64, privateKeyPEM []byte) (*Client, error) {
+func NewGitHubAppClient(ctx context.Context, appID, installationID int64, privateKeyPEM []byte) (*Client, error) {
 	// Create a new transport using the GitHub App authentication
-	itr, err := newGitHubAppTransport(appID, installationID, privateKeyPEM)
+	itr, err := newGitHubAppTransport(ctx, appID, installationID, privateKeyPEM)
 	if err != nil {
 		return nil, err
 	}
@@ -40,7 +40,7 @@ func NewGitHubAppClient(appID, installationID int64, privateKeyPEM []byte) (*Cli
 }
 
 // newGitHubAppTransport creates a new http.RoundTripper that authenticates as a GitHub App installation
-func newGitHubAppTransport(appID, installationID int64, privateKeyPEM []byte) (http.RoundTripper, error) {
+func newGitHubAppTransport(ctx context.Context, appID, installationID int64, privateKeyPEM []byte) (http.RoundTripper, error) {
 	// Parse the private key
 	privateKey, err := jwt.ParseRSAPrivateKeyFromPEM(privateKeyPEM)
 	if err != nil {
@@ -71,7 +71,7 @@ func newGitHubAppTransport(appID, installationID int64, privateKeyPEM []byte) (h
 
 	// Get installation token
 	installToken, _, err := client.Apps.CreateInstallationToken(
-		context.Background(),
+		ctx,
 		installationID,
 		&github.InstallationTokenOptions{},
 	)
@@ -87,8 +87,8 @@ func newGitHubAppTransport(appID, installationID int64, privateKeyPEM []byte) (h
 	}, nil
 }
 
-func (c *Client) GetLanguages(owner string, name string) (*Languages, error) {
-	langs, _, err := c.GitHubClient.Repositories.ListLanguages(context.Background(), owner, name)
+func (c *Client) GetLanguages(ctx context.Context, owner string, name string) (*Languages, error) {
+	langs, _, err := c.GitHubClient.Repositories.ListLanguages(ctx, owner, name)
 	if err != nil {
 		return nil, err
 	}

--- a/resources/plugin/client.go
+++ b/resources/plugin/client.go
@@ -90,12 +90,3 @@ func getTables() schema.Tables {
 	}
 	return tables
 }
-
-// Plugin returns the plugin configuration
-func Plugin() *plugin.Plugin {
-	return plugin.NewPlugin(
-		"github-languages",
-		"v1.0.0",
-		Configure,
-	)
-}

--- a/resources/plugin/client.go
+++ b/resources/plugin/client.go
@@ -52,6 +52,10 @@ func Configure(ctx context.Context, logger zerolog.Logger, spec []byte, opts plu
 }
 
 func (c *Client) Sync(ctx context.Context, options plugin.SyncOptions, res chan<- message.SyncMessage) error {
+	if c.syncClient == nil {
+		return fmt.Errorf("sync client is not initialized")
+	}
+
 	tt, err := c.tables.FilterDfs(options.Tables, options.SkipTables, options.SkipDependentTables)
 	if err != nil {
 		return err
@@ -85,4 +89,13 @@ func getTables() schema.Tables {
 		schema.AddCqIDs(t)
 	}
 	return tables
+}
+
+// Plugin returns the plugin configuration
+func Plugin() *plugin.Plugin {
+	return plugin.NewPlugin(
+		"github-languages",
+		"v1.0.0",
+		Configure,
+	)
 }

--- a/resources/services/table.go
+++ b/resources/services/table.go
@@ -29,7 +29,7 @@ func contains(s []string, str string) bool {
 	return false
 }
 
-func fetchRepositories(ctx context.Context, ghClient *gh.Client) ([]*gh.Repository, error) {
+func fetchRepositories(ctx context.Context, ghClient *gh.Client, org string) ([]*gh.Repository, error) {
 	opts := &gh.RepositoryListByOrgOptions{
 		ListOptions: gh.ListOptions{
 			PerPage: 100,
@@ -37,7 +37,7 @@ func fetchRepositories(ctx context.Context, ghClient *gh.Client) ([]*gh.Reposito
 
 	var allRepos []*gh.Repository
 	for {
-		repos, resp, err := ghClient.Repositories.ListByOrg(ctx, "guardian", opts)
+		repos, resp, err := ghClient.Repositories.ListByOrg(ctx, org, opts)
 		if err != nil {
 			return nil, err
 		}
@@ -73,7 +73,7 @@ func fetchLanguages(ctx context.Context, meta schema.ClientMeta, parent *schema.
 	}
 
 	// Use the official GitHub client for fetchRepositories
-	repos, err := fetchRepositories(ctx, gitHubClient.GitHubClient)
+	repos, err := fetchRepositories(ctx, gitHubClient.GitHubClient, c.Org())
 	if err != nil {
 		return err
 	}

--- a/resources/services/table.go
+++ b/resources/services/table.go
@@ -66,8 +66,8 @@ func fetchLanguages(ctx context.Context, meta schema.ClientMeta, parent *schema.
 	}
 
 	// Initialize GitHub client with App authentication
-	privateKeyBytes := []byte(c.PrivateKey())
-	gitHubClient, err := github.NewGitHubAppClient(ctx, c.AppID(), c.InstallationID(), privateKeyBytes)
+	privateKeyBytes := []byte(c.PrivateKey)
+	gitHubClient, err := github.NewGitHubAppClient(ctx, c.AppID, c.InstallationID, privateKeyBytes)
 	if err != nil {
 		return fmt.Errorf("failed to create GitHub App client: %w", err)
 	}

--- a/resources/services/table.go
+++ b/resources/services/table.go
@@ -65,9 +65,9 @@ func fetchLanguages(ctx context.Context, meta schema.ClientMeta, parent *schema.
 		return fmt.Errorf("failed to assert meta as *client.Client")
 	}
 
-	// Initialize GitHub client with App authentication only
-	privateKeyBytes := []byte(c.Spec.PrivateKey)
-	gitHubClient, err := github.NewGitHubAppClient(ctx, c.Spec.AppID, c.Spec.InstallationID, privateKeyBytes)
+	// Initialize GitHub client with App authentication
+	privateKeyBytes := []byte(c.PrivateKey())
+	gitHubClient, err := github.NewGitHubAppClient(ctx, c.AppID(), c.InstallationID(), privateKeyBytes)
 	if err != nil {
 		return fmt.Errorf("failed to create GitHub App client: %w", err)
 	}

--- a/resources/services/table.go
+++ b/resources/services/table.go
@@ -60,7 +60,10 @@ func fetchRepositories(ghClient *gh.Client) ([]*gh.Repository, error) {
 }
 
 func fetchLanguages(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- any) error {
-	c := meta.(*client.Client)
+	c, ok := meta.(*client.Client)
+	if !ok {
+		return fmt.Errorf("failed to assert meta as *client.Client")
+	}
 
 	// Initialize GitHub client with App authentication only
 	privateKeyBytes := []byte(c.Spec.PrivateKey)


### PR DESCRIPTION
## What does this change?

Linked to https://github.com/guardian/service-catalogue/pull/1537

This pull request enhances the client library to support GitHub App authentication instead of PAT authentication. It includes updates to the build process, client configuration, and documentation, as well as the addition of new dependencies. It also introduces a new GitHub App authentication testing tool (`test-auth`) to test this implementation thoroughly.

### Enhancements to Client Library:
* Updated `Spec` struct in `client/spec.go` to include fields for GitHub App authentication (`Org`, `AppID`, `InstallationID`, `PrivateKey`, `PrivateKeyPath`) (`client/spec.go`).
* Enhanced `New` function in `client/client.go` to validate and initialize GitHub App authentication parameters, including parsing PEM keys and handling file interpolation syntax (`client/client.go`).

### Build System Updates:
* Added a new `build-test-auth` target to the `Makefile` for building the `test-auth` tool (`Makefile`).

### Dependency Updates:
* Added `github.com/golang-jwt/jwt/v4` and `golang.org/x/oauth2` to support JWT-based authentication and OAuth2 token handling (`go.mod`).


### New GitHub App Authentication Tool:
* Added a new `test-auth` command-line utility for validating GitHub App authentication, including features like JWT and installation token validation, permission checks, and repository access testing (`cmd/test-auth/main.go`, `cmd/test-auth/README.md`). [[1]](diffhunk://#diff-19d859030f067632bd5520d51bbfcd798a8c7729da709d530804bdc1db78747cR1-R359) [[2]](diffhunk://#diff-e471b0b5a312b9a711954919fbd613e10735c8ee4c2f931b28c336ba876c60e4R1-R277)


## How to test

Run `make build-test-auth` in the repository root and then run the command `./test-auth --app-id=[x] --install-id=[y] --key=[z] --owner=guardian --repo=service-catalogue` and you should see a list of languages for the repo to confirm that authentication was successful. Use the service catalogue github credentials. I have tested this successfully with both `CODE` and `PROD` credentials.

## How can we measure success?

This will mean that we don't have to use a PAT to authenticate this plugin, which needs to be tied to a particular user and renewed every year at least. It makes the authentication more consistent with the way service catalogue authenticates and uses the same Github Apps (`CODE` and `PROD`) as the main Cloudquery plugin.

## Have we considered potential risks?

We need to release this change in order for it to be tested in CODE.