### PR TITLE
fix: update GoReleaser action version correct release arguments

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,14 +22,14 @@ jobs:
         with:
           go-version-file: go.mod
       - name: Run GoReleaser Dry-Run
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@9c156ee8a17a598857849441385a2041ef570552 #v6.3.0
         with:
           version: latest
-          args: release --clean --skip-validate --skip-publish --skip-sign
+          args: release --clean --skip=validate,publish,sign
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@9c156ee8a17a598857849441385a2041ef570552 #v6.3.0
         with:
           version: latest
-          args: release --clean --skip-sign
+          args: release --clean --skip=sign
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,6 +1,5 @@
 name: release
 on:
-  pull_request:
   push:
     tags:
       - 'v*.*.*'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,5 +1,6 @@
 name: release
 on:
+  pull_request:
   push:
     tags:
       - 'v*.*.*'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,20 +15,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version-file: go.mod
       - name: Run GoReleaser Dry-Run
-        uses: goreleaser/goreleaser-action@9c156ee8a17a598857849441385a2041ef570552 #v6.3.0
+        uses: goreleaser/goreleaser-action@9c156ee8a17a598857849441385a2041ef570552 # v6.3.0
         with:
           version: latest
           args: release --clean --skip=validate,publish,sign
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@9c156ee8a17a598857849441385a2041ef570552 #v6.3.0
+        uses: goreleaser/goreleaser-action@9c156ee8a17a598857849441385a2041ef570552 # v6.3.0
         with:
           version: latest
           args: release --clean --skip=sign


### PR DESCRIPTION
## What does this change?

The release workflow was broken because some flags have been deprecated. This PR:
- updates the flags to replace the deprecated syntax
- updates the `release.yaml` workflow to use a specific commit hash for the GoReleaser action.

## How to test

I have run this with the pull_request: trigger and the dry run ran successfully. The for-real release failed because the tags don't match the commit, probably due to the PR trigger. This hopefully indicates that the workflow will work 'for real'.

## How can we measure success?

We can release a new version of the plugin.

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
