### PR TITLE
Group nonbreaking dependency updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,8 +9,22 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      nonbreaking-golang:
+        patterns:
+          - '*'
+        update-types:
+          - minor
+          - patch
 
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
       interval: 'monthly'
+    groups:
+      nonbreaking-actions:
+        patterns:
+          - '*'
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Groups minor and patch dependency updates to reduce PR pressure


## How can we measure success?

Less PR fatigue